### PR TITLE
21 - Background Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ Además, contiene un servicio web que recibe la petición en fromato json y resp
 1. Se asume que se tiene aislado el ambiente de python, con todos los requerimientos listados en requirement.txt
 2. Crear las carpetas data/, plots/, models/
 3. Ejecutar BagOfWords.py
-4. Encender el servicio web:  ml_classifier.py
+4. Iniciar redis-server y `celery -A tasks worker --loglevel=info`
+5. Encender el servicio web:  ml_classifier.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ scipy==0.15.1
 six==1.9.0
 wsgiref==0.1.2
 elasticsearch==1.6.0
+celery[redis]

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,22 @@
+# Celery tasks
+
+from celery import Celery
+from sklearn.externals import joblib
+
+BROKER_URL = 'redis://localhost:6379/0'
+BROKER_TRANSPORT_OPTIONS = {'visibility_timeout': 1800}  # 1/2 hour.
+CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
+
+app = Celery('tasks', backend=CELERY_RESULT_BACKEND, broker=BROKER_URL)
+
+
+@app.task
+def evaluate_petition(features):
+    pipe = joblib.load('models/bow_ng6_nf9500_ne750.pkl')
+    test_data_features = pipe.named_steps['vectorizer'].transform(features)
+    test_data_features = test_data_features.toarray()
+    result = pipe.named_steps['forest'].predict(test_data_features)
+    print result
+    return result
+
+


### PR DESCRIPTION
Use celery and redis to send classification jobs to the background

PoC
[2015-06-19 01:47:59,428: INFO/MainProcess] Received task: tasks.evaluate_petition[ad551cbf-c134-4265-a3b2-72b781f72bab]
10.0.2.2 - - [19/Jun/2015 01:47:59] "POST /petition/classification HTTP/1.1" 201 -
[2015-06-19 01:48:22,167: INFO/MainProcess] Task tasks.evaluate_petition[ad551cbf-c134-4265-a3b2-72b781f72bab] succeeded in 22.735192742s: array([28])

Depends on #45 for testing
Do not forget to run `celery -A tasks worker --loglevel=info` in the background