### PR TITLE
Fire profanity filter on POST /petition/classification

### DIFF
--- a/ml_classifier.py
+++ b/ml_classifier.py
@@ -13,7 +13,8 @@ sys.path.append(os.path.dirname(__file__))
 from profanity_filter import *
 from nltk.corpus import stopwords
 import elasticsearch
-from tasks import evaluate_petition, catch_bad_words_in_text
+from tasks import evaluate_petition, catch_bad_words_in_text, build_classification_response
+from celery import chord
 
 
 app = Flask(__name__)
@@ -89,10 +90,17 @@ def create_task():
     features = review_words(task['text'])
     clean_test_descripciones.append(u" ".join(
         KaggleWord2VecUtility.review_to_wordlist(features, True)))
-    myeval = evaluate_petition.delay(clean_test_descripciones)
-    # Runs a job to detect bad words in text
-    bad_words_catcher = catch_bad_words_in_text.delay(task['text'])
-    # tasks.append(task)
+
+    # Uses chord to run two jobs and a callback after processing ends
+    # 1) A text classifier
+    # 2) A profanity filter
+    # 3) A callback to put all together in a JSON
+    callback = build_classification_response.subtask()
+    chord([
+        evaluate_petition.s(clean_test_descripciones),
+        catch_bad_words_in_text.s(task['text'])
+    ])(callback)
+
     return jsonify({'id': request.json['id'],
                     'text': request.json['text']}), 201
 

--- a/ml_classifier.py
+++ b/ml_classifier.py
@@ -13,7 +13,7 @@ sys.path.append(os.path.dirname(__file__))
 from profanity_filter import *
 from nltk.corpus import stopwords
 import elasticsearch
-from tasks import evaluate_petition
+from tasks import evaluate_petition, catch_bad_words_in_text
 
 
 app = Flask(__name__)
@@ -90,6 +90,8 @@ def create_task():
     clean_test_descripciones.append(u" ".join(
         KaggleWord2VecUtility.review_to_wordlist(features, True)))
     myeval = evaluate_petition.delay(clean_test_descripciones)
+    # Runs a job to detect bad words in text
+    bad_words_catcher = catch_bad_words_in_text.delay(task['text'])
     # tasks.append(task)
     return jsonify({'id': request.json['id'],
                     'text': request.json['text']}), 201

--- a/ml_classifier.py
+++ b/ml_classifier.py
@@ -97,7 +97,7 @@ def create_task():
     # 3) A callback to put all together in a JSON
     callback = build_classification_response.subtask()
     chord([
-        evaluate_petition.s(clean_test_descripciones),
+        evaluate_petition.s(task['id'], clean_test_descripciones),
         catch_bad_words_in_text.s(task['text'])
     ])(callback)
 

--- a/tasks.py
+++ b/tasks.py
@@ -3,6 +3,7 @@
 from celery import Celery
 from sklearn.externals import joblib
 from profanity_filter import *
+import json
 
 BROKER_URL = 'redis://localhost:6379/0'
 BROKER_TRANSPORT_OPTIONS = {'visibility_timeout': 1800}  # 1/2 hour.
@@ -16,16 +17,31 @@ def evaluate_petition(features):
     pipe = joblib.load('models/bow_ng6_nf9500_ne750.pkl')
     test_data_features = pipe.named_steps['vectorizer'].transform(features)
     test_data_features = test_data_features.toarray()
+    # TODO: check API of this method, what's returning on error?
     result = pipe.named_steps['forest'].predict(test_data_features)
-    print result
-    return result
+    if len(result) > 0:
+        return result[0]
+    else:
+        return -1
 
 
 @app.task
 def catch_bad_words_in_text(text):
     f = ProfanitiesFilter(my_list, replacements="-")
+    # TODO: check API of this method, what's returning on error?
     profanity_score = f.profanity_score(text)
-    print profanity_score
     return profanity_score
+
+
+@app.task
+def build_classification_response(results):
+    profanity_score = results[1]
+    proceeds = False if profanity_score > 0 else True
+
+    response = {
+            'agency': results[0],
+            'proceeds': proceeds
+            }
+    print json.dumps(response)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -13,16 +13,16 @@ app = Celery('tasks', backend=CELERY_RESULT_BACKEND, broker=BROKER_URL)
 
 
 @app.task
-def evaluate_petition(features):
+def evaluate_petition(petition_id, features):
     pipe = joblib.load('models/bow_ng6_nf9500_ne750.pkl')
     test_data_features = pipe.named_steps['vectorizer'].transform(features)
     test_data_features = test_data_features.toarray()
     # TODO: check API of this method, what's returning on error?
     result = pipe.named_steps['forest'].predict(test_data_features)
-    if len(result) > 0:
-        return result[0]
-    else:
-        return -1
+    return {
+        'id': petition_id,
+        'agency': result[0] if len(result) > 0 else -1
+    }
 
 
 @app.task
@@ -30,16 +30,22 @@ def catch_bad_words_in_text(text):
     f = ProfanitiesFilter(my_list, replacements="-")
     # TODO: check API of this method, what's returning on error?
     profanity_score = f.profanity_score(text)
-    return profanity_score
+    return {
+        'text': text,
+        'profanity_score': profanity_score
+    }
 
 
 @app.task
 def build_classification_response(results):
-    profanity_score = results[1]
-    proceeds = False if profanity_score > 0 else True
+    classified_petition = results[0]
+    inspected_text = results[1]
+    proceeds = False if inspected_text['profanity_score'] > 0 else True
 
     response = {
-            'agency': results[0],
+            'id': classified_petition['id'],
+            'text': inspected_text['text'],
+            'agency': classified_petition['agency'],
             'proceeds': proceeds
             }
     print json.dumps(response)

--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@
 
 from celery import Celery
 from sklearn.externals import joblib
+from profanity_filter import *
 
 BROKER_URL = 'redis://localhost:6379/0'
 BROKER_TRANSPORT_OPTIONS = {'visibility_timeout': 1800}  # 1/2 hour.
@@ -18,5 +19,13 @@ def evaluate_petition(features):
     result = pipe.named_steps['forest'].predict(test_data_features)
     print result
     return result
+
+
+@app.task
+def catch_bad_words_in_text(text):
+    f = ProfanitiesFilter(my_list, replacements="-")
+    profanity_score = f.profanity_score(text)
+    print profanity_score
+    return profanity_score
 
 


### PR DESCRIPTION
```
vagrant@debian-800-jessie:/vagrant$ python ml_classifier.py 
 * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 * Restarting with stat
[2015-06-22 21:22:53,943: INFO/MainProcess] Received task: tasks.evaluate_petition[48e1d1fc-f30c-490b-8f4e-9d3fa3ecfd9a]
[2015-06-22 21:22:53,955: INFO/MainProcess] Received task: tasks.catch_bad_words_in_text[642222ca-0d2d-47a0-b4ee-fb14206f5875]
10.0.2.2 - - [22/Jun/2015 21:22:53] "POST /petition/classification HTTP/1.1" 201 -

[2015-06-22 21:23:19,696: WARNING/Worker-1] [28]
[2015-06-22 21:23:20,046: INFO/MainProcess] Task tasks.evaluate_petition[48e1d1fc-f30c-490b-8f4e-9d3fa3ecfd9a] succeeded in 26.101022668s: array([28])
[2015-06-22 21:23:20,067: WARNING/Worker-1] {u'me': 0, u'porque': 0, u'necesito': 0, u'casita': 0, u'digna': 0, u'para': 0, u'dieran': 0, u'vivienda': 0, u'prestamo': 0, u'o': 0, u'comprar': 0, u'una': 0, u'un': 0, u'del': 0, u'departamento': 0, u'quisiera': 0, u'ue': 0, u'infonavit,': 0}
[2015-06-22 21:23:20,068: WARNING/Worker-1] 0
[2015-06-22 21:23:20,070: INFO/MainProcess] Task tasks.catch_bad_words_in_text[642222ca-0d2d-47a0-b4ee-fb14206f5875] succeeded in 0.0226751989999s: 0
```

### TODO
- [x] fire both jobs on POST request
- [x] wait for both results and return a JSON
- [x] pass original values to final JSON

### HOW TO TEST
Celery output should include the following:
```json
{
    "text": "Quisiera ue me dieran un prestamo para comprar una casita o un departamento del infonavit, porque necesito una vivienda digna y chingona",
    "agency": 28,
    "id": "20150430GOBMEX",
    "proceeds": false
}
```