### PR TITLE
changes the 'proceeds' filed, in order to add the reason to reject it

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,5 @@
 # Celery tasks
+# -*- coding: utf-8 -*-
 
 from celery import Celery
 from sklearn.externals import joblib
@@ -41,7 +42,10 @@ def catch_bad_words_in_text(text):
 def update_remote_petition(results):
     classified_petition = results[0]
     inspected_text = results[1]
-    proceeds = False if inspected_text['profanity_score'] > 0 else True
+    if inspected_text['profanity_score'] > 0:
+        proceeds = {'value': False, 'reason': u'Petición Irrespetuosa'.encode('utf-8')}
+    else:
+        proceeds = {'value': True}
 
     petition = {
         'id': classified_petition['id'],

--- a/tasks.py
+++ b/tasks.py
@@ -1,11 +1,12 @@
-# Celery tasks
 # -*- coding: utf-8 -*-
+# Celery tasks
 
 from celery import Celery
 from sklearn.externals import joblib
 from profanity_filter import *
 import requests
 import os
+import json
 
 BROKER_URL = 'redis://localhost:6379/0'
 BROKER_TRANSPORT_OPTIONS = {'visibility_timeout': 1800}  # 1/2 hour.
@@ -43,21 +44,21 @@ def update_remote_petition(results):
     classified_petition = results[0]
     inspected_text = results[1]
     if inspected_text['profanity_score'] > 0:
-        proceeds = {'value': False, 'reason': u'Petición Irrespetuosa'.encode('utf-8')}
+        proceeds = {u'value': False, u'reason': u'Petición Irrespetuosa'}
     else:
-        proceeds = {'value': True}
+        proceeds = {u'value': True}
 
     petition = {
-        'id': classified_petition['id'],
-        'text': inspected_text['text'],
-        'agency': classified_petition['agency'],
-        'proceeds': proceeds
+        u'id': classified_petition['id'],
+        u'text': inspected_text['text'],
+        u'agency': classified_petition['agency'],
+        u'proceeds': proceeds
     }
 
     url = os.environ['PETITIONS_SERVER_URL']
     r = requests.put(url, data=petition)
     print 'Updating:'
-    print petition
+    print json.dumps(petition, encoding='utf-8', ensure_ascii=False)
     print 'PUT request to', url, ' was ', r.status_code
 
 


### PR DESCRIPTION
# How to test:

`curl -u <<token>>:<<secret>> -i -H "Content-Type: application/json;charset=UTF-8" -X POST -d '{"id":"20150430GOBMEX","text":"Quisiera ue me dieran un prestamo para comprar una casita o un departamento del infonavit, porque necesito una vivienda digna, y no la pinche pocilga en la que vivo"}' http://104.154.61.123:5000/petition/classification`

Si aún no tienes el <<token>>, checa el PR https://github.com/mxabierto/sara/pull/57.
También es necesario definir `PETITIONS_SERVER_URL`
`export PETITIONS_SERVER_URL="0.0.0.0/update"`
En el output de `celery -A tasks worker --loglevel=info`, debes obtener algo similar a

[2015-06-25 20:37:20,124: INFO/Worker-1] Starting new HTTP connection (1): www.gob.mx
[2015-06-25 20:37:21,200: WARNING/Worker-1] Updating:
**[2015-06-25 20:37:21,201: WARNING/Worker-1] {"text": "Quisiera ue me dieran un prestamo para comprar una casita o un departamento del infonavit, porque necesito una vivienda digna, y no la pinche pocilga en la que vivo", "agency": 28, "id": "20150430GOBMEX", "proceeds": {"reason": "Petición Irrespetuosa", "value": false}}**
[2015-06-25 20:37:21,201: WARNING/Worker-1] PUT request to
[2015-06-25 20:37:21,201: WARNING/Worker-1] http://www.gob.mx/SAC/petitionClassifier/update
[2015-06-25 20:37:21,201: WARNING/Worker-1] was
[2015-06-25 20:37:21,201: WARNING/Worker-1] 200
[2015-06-25 20:37:21,202: INFO/MainProcess] Task tasks.update_remote_petition[aaff6b7c-5259-4e76-b51e-89f374d21934] succeeded in 1.07930530497s: None`
