### PR TITLE
solves #86

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -6,7 +6,6 @@ from celery import Celery
 from sklearn.externals import joblib
 from profanity_filter import *
 import requests
-import sys
 import json
 
 REDIS_HOST = os.getenv( 'REDIS_PORT_6379_TCP_ADDR', 'localhost' )+':'+os.getenv( 'REDIS_PORT_6379_TCP_PORT', '6379' )

--- a/tasks.py
+++ b/tasks.py
@@ -64,7 +64,12 @@ def update_remote_petition(results):
         print 'Updating:'
         print json.dumps(petition, encoding='utf-8', ensure_ascii=False)
         print 'PUT request to', url, ' was ', r.status_code
-    except requests.exceptions.RequestException as e:
+        r.raise_for_status() # Rise an exception if status code is not 200
+    except requests.HTTPError as e: 
+        print 'HTTP ERROR occured, status code %s' % e.response.status_code
+        print 'ERROR reason: %s'  % e.response.reason
         print e
-        sys.exit(1)
+    except requests.exceptions.RequestException as e: # Catch all non HTTP errors
+        print 'An unexpected error ocurred.' 
+        print e 
 

--- a/tasks.py
+++ b/tasks.py
@@ -6,7 +6,7 @@ from celery import Celery
 from sklearn.externals import joblib
 from profanity_filter import *
 import requests
-import os
+import sys
 import json
 
 REDIS_HOST = os.getenv( 'REDIS_PORT_6379_TCP_ADDR', 'localhost' )+':'+os.getenv( 'REDIS_PORT_6379_TCP_PORT', '6379' )
@@ -59,9 +59,12 @@ def update_remote_petition(results):
 
     url = os.environ['PETITIONS_SERVER_URL']
     headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-    r = requests.put(url, data=json.dumps(petition), headers=headers)
-    print 'Updating:'
-    print json.dumps(petition, encoding='utf-8', ensure_ascii=False)
-    print 'PUT request to', url, ' was ', r.status_code
-
+    try:
+        r = requests.put(url, data=json.dumps(petition), headers=headers)
+        print 'Updating:'
+        print json.dumps(petition, encoding='utf-8', ensure_ascii=False)
+        print 'PUT request to', url, ' was ', r.status_code
+    except requests.exceptions.RequestException as e:
+        print e
+        sys.exit(1)
 

--- a/tasks.py
+++ b/tasks.py
@@ -70,6 +70,8 @@ def update_remote_petition(results):
         print 'ERROR reason: %s'  % e.response.reason
         print e
     except requests.exceptions.RequestException as e: # Catch all non HTTP errors
+        # example: ConnectionError, URLRequired, TooManyRedirects, ConnectTimeout,
+        # ReadTimeout
         print 'An unexpected error ocurred.' 
         print e 
 


### PR DESCRIPTION
### Cómo probar:

Settear vacía o errónea la variable PETITIONS_SERVER_URL y ver que en los logs de celery.log no se rompa el proceso se imprima la razón de la falla.
